### PR TITLE
replaced all usages of boost::thread by their C++ 11 equivalents

### DIFF
--- a/Hypodermic/ComponentRegistry.cpp
+++ b/Hypodermic/ComponentRegistry.cpp
@@ -14,7 +14,7 @@ namespace Hypodermic
 
     std::shared_ptr< IComponentRegistration > ComponentRegistry::getRegistration(std::shared_ptr< Service > service)
     {
-        boost::lock_guard< decltype (mutex_) > lock(mutex_);
+        std::lock_guard< decltype (mutex_) > lock(mutex_);
         
         auto info = getInitializedServiceInfo(service);
         return info->getRegistration();
@@ -25,7 +25,7 @@ namespace Hypodermic
         if (service == nullptr)
             throw std::invalid_argument("service");
 
-        boost::lock_guard< decltype (mutex_) > lock(mutex_);
+        std::lock_guard< decltype (mutex_) > lock(mutex_);
         return getInitializedServiceInfo(service)->isRegistered();
     }
 
@@ -36,7 +36,7 @@ namespace Hypodermic
 
     void ComponentRegistry::addRegistration(std::shared_ptr< IComponentRegistration > registration, bool /* preserveDefaults */)
     {
-        boost::lock_guard< decltype (mutex_) > lock(mutex_);
+        std::lock_guard< decltype (mutex_) > lock(mutex_);
 
         BOOST_FOREACH(auto service, registration->services())
         {
@@ -48,13 +48,13 @@ namespace Hypodermic
 
     std::vector< std::shared_ptr< IComponentRegistration > > ComponentRegistry::registrations()
     {
-        boost::lock_guard< decltype (mutex_) > lock(mutex_);
+        std::lock_guard< decltype (mutex_) > lock(mutex_);
         return registrations_;
     }
 
     std::vector< std::shared_ptr< IComponentRegistration > > ComponentRegistry::registrationsFor(std::shared_ptr< Service > service)
     {
-        boost::lock_guard< boost::recursive_mutex > lock(mutex_);
+        std::lock_guard< decltype (mutex_) > lock(mutex_);
 
         auto info = getInitializedServiceInfo(service);
         return info->implementations();
@@ -132,7 +132,7 @@ namespace Hypodermic
         if (source == nullptr)
             throw std::invalid_argument("source");
 
-        boost::lock_guard< boost::recursive_mutex > lock(mutex_);
+        std::lock_guard< decltype (mutex_) > lock(mutex_);
 
         dynamicRegistrationSources_.push_front(source);
 

--- a/Hypodermic/ComponentRegistry.h
+++ b/Hypodermic/ComponentRegistry.h
@@ -5,8 +5,7 @@
 # include <memory>
 # include <unordered_map>
 # include <vector>
-
-# include <boost/thread.hpp>
+# include <mutex>
 
 # include <Hypodermic/IComponentRegistry.h>
 # include <Hypodermic/ServiceKey.h>
@@ -47,7 +46,7 @@ namespace Hypodermic
         std::vector< std::shared_ptr< IComponentRegistration > > registrations_;
         std::deque< std::shared_ptr< IRegistrationSource > > dynamicRegistrationSources_;
 		ServiceRegistrationInfos serviceInfo_;
-		boost::recursive_mutex mutex_;
+		std::recursive_mutex mutex_;
 	};
 
 } // namespace Hypodermic

--- a/Hypodermic/LifetimeScope.cpp
+++ b/Hypodermic/LifetimeScope.cpp
@@ -54,7 +54,7 @@ namespace Hypodermic
             throw std::invalid_argument("registration");
 
         {
-            boost::lock_guard< decltype(mutex_) > lock(mutex_);
+            std::lock_guard< decltype(mutex_) > lock(mutex_);
 
             auto operation = std::make_shared< ResolveOperation >(shared_from_this());
             return operation->execute(registration);
@@ -64,7 +64,7 @@ namespace Hypodermic
     std::shared_ptr< void > LifetimeScope::getOrCreateAndShare(const boost::uuids::uuid& id,
                                                                std::function< std::shared_ptr< void >() > creator)
     {
-        boost::lock_guard< decltype(mutex_) > lock(mutex_);
+        std::lock_guard< decltype(mutex_) > lock(mutex_);
 
         std::shared_ptr< void > result;
         if (sharedInstances_.count(id) == 0)

--- a/Hypodermic/LifetimeScope.h
+++ b/Hypodermic/LifetimeScope.h
@@ -4,8 +4,8 @@
 # include <functional>
 # include <memory>
 # include <unordered_map>
+# include <mutex>
 
-# include <boost/thread.hpp>
 # include <boost/uuid/uuid.hpp>
 
 # include <Hypodermic/BoostUuidHashFunctor.h>
@@ -50,7 +50,7 @@ namespace Hypodermic
 		std::weak_ptr< ISharingLifetimeScope > root_;
 		std::unordered_map< boost::uuids::uuid, std::shared_ptr< void > > sharedInstances_;
 
-        boost::recursive_mutex mutex_;
+        std::recursive_mutex mutex_;
 
 		static std::function< void(ContainerBuilder&) > noConfiguration_;
 	};


### PR DESCRIPTION
Since C++11 provides its own mutex classes, hypodermic could be built w/o the dependency to boost::thread.