### PR TITLE
Introduced registerFactory

### DIFF
--- a/Hypodermic.Tests/ContainerBuilderTests.cpp
+++ b/Hypodermic.Tests/ContainerBuilderTests.cpp
@@ -151,6 +151,20 @@ BOOST_AUTO_TEST_CASE(should_resolve_abstract_dependencies)
 	BOOST_CHECK(serviceB != nullptr);
 }
 
+BOOST_AUTO_TEST_CASE(factory_works_as_type)
+{
+    ContainerBuilder builder;
+
+    builder.registerType< ServiceA >()->as< IServiceA >();
+    builder.registerFactory< ServiceB >(CREATE(std::make_shared< ServiceB >(INJECT(IServiceA))))->as< IServiceB >();
+
+    auto container = builder.build();
+
+    auto serviceB = container->resolve< IServiceB >();
+
+    BOOST_CHECK(serviceB != nullptr);
+}
+
 BOOST_AUTO_TEST_CASE(default_lifetime_should_be_transient)
 {
 	ContainerBuilder builder;

--- a/Hypodermic/AutowiredConstructor.h
+++ b/Hypodermic/AutowiredConstructor.h
@@ -70,11 +70,11 @@ namespace Hypodermic
 
         typedef std::true_type IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext&) -> T*
+            return [](IComponentContext&) -> std::shared_ptr< T >
             {
-                return new T();
+                return std::make_shared<T>();
             };
         }
     };
@@ -86,11 +86,11 @@ namespace Hypodermic
 
         typedef BoolType< ArgResolver< Arg1 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c));
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c));
             };
         }
     };
@@ -103,11 +103,11 @@ namespace Hypodermic
         typedef BoolType< ArgResolver< Arg1 >::IsResolvable::value
                        && ArgResolver< Arg2 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c));
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c));
             };
         }
     };
@@ -121,12 +121,12 @@ namespace Hypodermic
                        && ArgResolver< Arg2 >::IsResolvable::value
                        && ArgResolver< Arg3 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
-                             ArgResolver< Arg3 >::resolve(c));
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
+                                           ArgResolver< Arg3 >::resolve(c));
             };
         }
     };
@@ -141,11 +141,11 @@ namespace Hypodermic
                        && ArgResolver< Arg3 >::IsResolvable::value
                        && ArgResolver< Arg4 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
                              ArgResolver< Arg3 >::resolve(c), ArgResolver< Arg4 >::resolve(c));
             };
         }
@@ -162,11 +162,11 @@ namespace Hypodermic
                        && ArgResolver< Arg4 >::IsResolvable::value
                        && ArgResolver< Arg5 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
                              ArgResolver< Arg3 >::resolve(c), ArgResolver< Arg4 >::resolve(c),
                              ArgResolver< Arg5 >::resolve(c));
             };
@@ -185,11 +185,11 @@ namespace Hypodermic
                        && ArgResolver< Arg5 >::IsResolvable::value
                        && ArgResolver< Arg6 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
                              ArgResolver< Arg3 >::resolve(c), ArgResolver< Arg4 >::resolve(c),
                              ArgResolver< Arg5 >::resolve(c), ArgResolver< Arg6 >::resolve(c));
             };
@@ -209,11 +209,11 @@ namespace Hypodermic
                        && ArgResolver< Arg6 >::IsResolvable::value
                        && ArgResolver< Arg7 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
                              ArgResolver< Arg3 >::resolve(c), ArgResolver< Arg4 >::resolve(c),
                              ArgResolver< Arg5 >::resolve(c), ArgResolver< Arg6 >::resolve(c),
                              ArgResolver< Arg7 >::resolve(c));
@@ -235,11 +235,11 @@ namespace Hypodermic
                        && ArgResolver< Arg7 >::IsResolvable::value
                        && ArgResolver< Arg8 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
                              ArgResolver< Arg3 >::resolve(c), ArgResolver< Arg4 >::resolve(c),
                              ArgResolver< Arg5 >::resolve(c), ArgResolver< Arg6 >::resolve(c),
                              ArgResolver< Arg7 >::resolve(c), ArgResolver< Arg8 >::resolve(c));
@@ -262,11 +262,11 @@ namespace Hypodermic
                        && ArgResolver< Arg8 >::IsResolvable::value
                        && ArgResolver< Arg9 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
                              ArgResolver< Arg3 >::resolve(c), ArgResolver< Arg4 >::resolve(c),
                              ArgResolver< Arg5 >::resolve(c), ArgResolver< Arg6 >::resolve(c),
                              ArgResolver< Arg7 >::resolve(c), ArgResolver< Arg8 >::resolve(c),
@@ -291,11 +291,11 @@ namespace Hypodermic
                        && ArgResolver< Arg9 >::IsResolvable::value
                        && ArgResolver< Arg10 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
                              ArgResolver< Arg3 >::resolve(c), ArgResolver< Arg4 >::resolve(c),
                              ArgResolver< Arg5 >::resolve(c), ArgResolver< Arg6 >::resolve(c),
                              ArgResolver< Arg7 >::resolve(c), ArgResolver< Arg8 >::resolve(c),
@@ -321,11 +321,11 @@ namespace Hypodermic
                        && ArgResolver< Arg10 >::IsResolvable::value
                        && ArgResolver< Arg11 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
                              ArgResolver< Arg3 >::resolve(c), ArgResolver< Arg4 >::resolve(c),
                              ArgResolver< Arg5 >::resolve(c), ArgResolver< Arg6 >::resolve(c),
                              ArgResolver< Arg7 >::resolve(c), ArgResolver< Arg8 >::resolve(c),
@@ -353,11 +353,11 @@ namespace Hypodermic
                        && ArgResolver< Arg11 >::IsResolvable::value
                        && ArgResolver< Arg12 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
                              ArgResolver< Arg3 >::resolve(c), ArgResolver< Arg4 >::resolve(c),
                              ArgResolver< Arg5 >::resolve(c), ArgResolver< Arg6 >::resolve(c),
                              ArgResolver< Arg7 >::resolve(c), ArgResolver< Arg8 >::resolve(c),
@@ -386,11 +386,11 @@ namespace Hypodermic
                        && ArgResolver< Arg12 >::IsResolvable::value
                        && ArgResolver< Arg13 >::IsResolvable::value > IsSignatureRecognized;
 
-        static std::function< T*(IComponentContext&) > createDelegate()
+        static std::function< std::shared_ptr< T >(IComponentContext&) > createDelegate()
         {
-            return [](IComponentContext& c) -> T*
+            return [](IComponentContext& c) -> std::shared_ptr< T >
             {
-                return new T(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
+                return std::make_shared<T>(ArgResolver< Arg1 >::resolve(c), ArgResolver< Arg2 >::resolve(c),
                              ArgResolver< Arg3 >::resolve(c), ArgResolver< Arg4 >::resolve(c),
                              ArgResolver< Arg5 >::resolve(c), ArgResolver< Arg6 >::resolve(c),
                              ArgResolver< Arg7 >::resolve(c), ArgResolver< Arg8 >::resolve(c),

--- a/Hypodermic/Container.cpp
+++ b/Hypodermic/Container.cpp
@@ -48,7 +48,7 @@ namespace Hypodermic
                 LifetimeScope::selfRegistrationId,
                 std::make_shared< DelegateActivator< LifetimeScope > >(
                     typeid(LifetimeScope),
-                    [](IComponentContext&) -> LifetimeScope*
+                    [](IComponentContext&) -> std::shared_ptr<LifetimeScope>
                     {
                         throw std::logic_error("Self registration cannot be activated");
                     }),

--- a/Hypodermic/ContainerBuilder.h
+++ b/Hypodermic/ContainerBuilder.h
@@ -39,6 +39,9 @@ namespace Hypodermic
         template <class T>
         std::shared_ptr< typename RegistrationBuilderInterface< T >::Type > registerType(std::function< T*(IComponentContext&) > delegate);
 
+        template <class T>
+        std::shared_ptr< typename RegistrationBuilderInterface< T >::Type > registerFactory(std::function< std::shared_ptr<T>(IComponentContext&) > delegate);
+
 		template <class T>
 		std::shared_ptr< typename RegistrationBuilderInterface< T >::Type > registerType();
 

--- a/Hypodermic/ContainerBuilder.hpp
+++ b/Hypodermic/ContainerBuilder.hpp
@@ -36,6 +36,30 @@ namespace Hypodermic
         static_assert(!std::is_pod< T >::value || std::is_empty< T >::value || std::is_class< T >::value,
                       "ContainerBuilder::registerType< T >() is incompatible with POD types.");
 
+        std::function< std::shared_ptr< T >(IComponentContext&) > delegateWrapper = [delegate](IComponentContext& c)->std::shared_ptr < T >
+        {
+            return std::shared_ptr< T >(delegate(c));
+        };
+
+        auto rb = RegistrationBuilderFactory< ContainerBuilder::RegistrationBuilderInterface >::forDelegate(delegateWrapper);
+
+        registerCallback(
+            [rb](std::shared_ptr< IComponentRegistry > cr) -> void
+            {
+                RegistrationBuilderFactory< ContainerBuilder::RegistrationBuilderInterface >::registerSingleComponent< T >(cr, rb);
+            });
+
+        return rb;
+    }
+
+    template <class T>
+    std::shared_ptr< typename ContainerBuilder::RegistrationBuilderInterface< T >::Type >
+        ContainerBuilder::registerFactory(std::function< std::shared_ptr<T>(IComponentContext&) > delegate)
+    {
+        static_assert(!std::is_pod< T >::value || std::is_empty< T >::value || std::is_class< T >::value,
+            "ContainerBuilder::registerType< T >() is incompatible with POD types.");
+
+        auto& typeInfo = typeid(T);
         auto rb = RegistrationBuilderFactory< ContainerBuilder::RegistrationBuilderInterface >::forDelegate(delegate);
 
         registerCallback(

--- a/Hypodermic/ContainerBuilder.hpp
+++ b/Hypodermic/ContainerBuilder.hpp
@@ -57,9 +57,8 @@ namespace Hypodermic
         ContainerBuilder::registerFactory(std::function< std::shared_ptr<T>(IComponentContext&) > delegate)
     {
         static_assert(!std::is_pod< T >::value || std::is_empty< T >::value || std::is_class< T >::value,
-            "ContainerBuilder::registerType< T >() is incompatible with POD types.");
+            "ContainerBuilder::registerFactory< T >() is incompatible with POD types.");
 
-        auto& typeInfo = typeid(T);
         auto rb = RegistrationBuilderFactory< ContainerBuilder::RegistrationBuilderInterface >::forDelegate(delegate);
 
         registerCallback(

--- a/Hypodermic/DelegateActivator.h
+++ b/Hypodermic/DelegateActivator.h
@@ -16,7 +16,7 @@ namespace Hypodermic
 	template <class T>
 	class DelegateActivator : public InstanceActivator
 	{
-        typedef std::function< T*(IComponentContext&) > ActivationDelegate;
+        typedef std::function< std::shared_ptr< T >(IComponentContext&) > ActivationDelegate;
 
 	public:
 		DelegateActivator(const std::type_info& typeInfo, ActivationDelegate activationFunction);

--- a/Hypodermic/DelegateActivator.hpp
+++ b/Hypodermic/DelegateActivator.hpp
@@ -16,7 +16,7 @@ namespace Hypodermic
     template <class T>
 	inline std::shared_ptr< void > DelegateActivator< T >::activateInstance(std::shared_ptr< IComponentContext > context)
 	{
-		return std::shared_ptr< void >(activationFunction_(*context));
+		return activationFunction_(*context);
 	}
 
     inline DelegateActivator< void >::DelegateActivator(const std::type_info& typeInfo, ActivationDelegate activationFunction)

--- a/Hypodermic/RegistrationBuilderFactory.h
+++ b/Hypodermic/RegistrationBuilderFactory.h
@@ -26,9 +26,9 @@ namespace Hypodermic
 	{
 	public:
 		template <class T>
-		static std::shared_ptr< typename RegistrationBuilderInterfaceT< T >::Type > forDelegate(std::function< T*(IComponentContext&) > delegate);
-
-		static std::shared_ptr< typename RegistrationBuilderInterfaceT< void >::Type >
+		static std::shared_ptr< typename RegistrationBuilderInterfaceT< T >::Type > forDelegate(std::function< std::shared_ptr< T >(IComponentContext&) > delegate);
+        
+        static std::shared_ptr< typename RegistrationBuilderInterfaceT< void >::Type >
         forDelegate(const std::type_info& typeInfo,
                     std::function
                         <

--- a/Hypodermic/RegistrationBuilderFactory.hpp
+++ b/Hypodermic/RegistrationBuilderFactory.hpp
@@ -19,7 +19,7 @@ namespace Hypodermic
     template <template <class> class RegistrationBuilderInterfaceT>
     template <class T>
 	std::shared_ptr< typename RegistrationBuilderInterfaceT< T >::Type >
-    RegistrationBuilderFactory< RegistrationBuilderInterfaceT >::forDelegate(std::function< T*(IComponentContext&) > delegate)
+    RegistrationBuilderFactory< RegistrationBuilderInterfaceT >::forDelegate(std::function< std::shared_ptr< T >(IComponentContext&) > delegate)
 	{
         auto& typeInfo = typeid(T);
 		return std::make_shared< typename RegistrationBuilderInterfaceT< T >::ImplementationType >(
@@ -51,7 +51,7 @@ namespace Hypodermic
         auto& typeInfo = typeid(T);
 		return std::make_shared< typename RegistrationBuilderInterfaceT< T >::ImplementationType >(
             std::make_shared< TypedService >(typeInfo),
-			std::make_shared< DelegateActivator< T > >(typeInfo, [](IComponentContext&) -> T* { return new T; }),
+			std::make_shared< DelegateActivator< T > >(typeInfo, [](IComponentContext&) -> std::shared_ptr<T> { return std::make_shared<T>(); }),
             typename RegistrationBuilderInterfaceT< T >::RegistrationStyleType());
 	}
 


### PR DESCRIPTION
`registerFactory(delegate)` works like `registerType(delegate)`, with
the
difference of the delegate returning a `shared_ptr` to the created
object