### PR TITLE
fix clang build warnings

### DIFF
--- a/Hypodermic/BoostUuidHashFunctor.h
+++ b/Hypodermic/BoostUuidHashFunctor.h
@@ -9,7 +9,7 @@ namespace std
 {
 
     template <>
-    class hash< boost::uuids::uuid > : public std::unary_function< boost::uuids::uuid, size_t >
+    struct hash< boost::uuids::uuid > : public std::unary_function< boost::uuids::uuid, size_t >
     {	// hash functor
     public:
         std::size_t operator()(const boost::uuids::uuid& _Keyval) const

--- a/Hypodermic/ServiceKey.h
+++ b/Hypodermic/ServiceKey.h
@@ -28,7 +28,7 @@ namespace std
 {
 
     template <>
-    class hash< Hypodermic::ServiceKey > : public unary_function< Hypodermic::ServiceKey, size_t >
+    struct hash< Hypodermic::ServiceKey > : public unary_function< Hypodermic::ServiceKey, size_t >
     {
     public:
         size_t operator()(const Hypodermic::ServiceKey& key) const


### PR DESCRIPTION
replaced 'class' with 'struct' when specializing 'hash' to remove clang build warning.

as i'm using hypodermic with my own custom CMakeLists.txt that statically links the sources from Hypodermic/Hypodermic, i haven't looked outside that dir.