### PR TITLE
Fix a bug in NestedRegistrationScope where scopes could not be nested to more than one level

### DIFF
--- a/Hypodermic.Tests/NestedContainerTests.cpp
+++ b/Hypodermic.Tests/NestedContainerTests.cpp
@@ -54,6 +54,42 @@ namespace Testing
         BOOST_CHECK_EQUAL(instance->dependency->i, expectedNumber);
     }
 
+    BOOST_AUTO_TEST_CASE(should_resolve_dependency_in_nested_of_nested_container)
+    {
+        // Arrange
+        int expectedNumber1 = 42;
+        int expectedNumber2 = 43;
+
+        ContainerBuilder builder;
+        builder.registerType< TopLevelConstructor >();
+
+        auto container = builder.build();
+
+        ContainerBuilder nestedContainerBuilder1;
+        nestedContainerBuilder1.registerInstance(std::make_shared< NestedDependency >(expectedNumber1));
+        auto nestedContainer1 = nestedContainerBuilder1.buildNestedContainerFrom(*container);
+
+        // Act
+        ContainerBuilder nestedContainerBuilder2;
+        nestedContainerBuilder2.registerInstance(std::make_shared< NestedDependency >(expectedNumber2));
+        auto nestedContainer2 = nestedContainerBuilder2.buildNestedContainerFrom(*nestedContainer1);
+
+        // Assert
+        auto instance = container->resolve< TopLevelConstructor >();
+        BOOST_REQUIRE(instance != nullptr);
+        BOOST_CHECK(instance->dependency == nullptr);
+
+        instance = nestedContainer1->resolve< TopLevelConstructor >();
+        BOOST_REQUIRE(instance != nullptr);
+        BOOST_REQUIRE(instance->dependency != nullptr);
+        BOOST_CHECK_EQUAL(instance->dependency->i, expectedNumber1);
+
+        instance = nestedContainer2->resolve< TopLevelConstructor >();
+        BOOST_REQUIRE(instance != nullptr);
+        BOOST_REQUIRE(instance->dependency != nullptr);
+        BOOST_CHECK_EQUAL(instance->dependency->i, expectedNumber2);
+    }
+
     BOOST_AUTO_TEST_CASE(should_keep_reference_on_top_level_registrations)
     {
         // Arrange

--- a/Hypodermic/NestedRegistrationScope.h
+++ b/Hypodermic/NestedRegistrationScope.h
@@ -41,7 +41,7 @@ namespace Hypodermic
 
             auto scopeClone = std::make_shared< NestedRegistrationScope >(PrivateTag());
             scopeClone->m_parentScope = m_parentScope;
-            scopeClone->m_scope = m_scope;
+            scopeClone->m_scope = m_scope->clone();
 
             return scopeClone;
         }


### PR DESCRIPTION
Currently, Hypodermic cannot handle a nested scope where its parent is also nested. This is probably due to a missing `m_scope->clone()` call missing when cloning the NestedRegistrationScope instance (which will get called by the second-level scope `scope()` method)

The test new test case provides a situation in which Hypodermic was failing.