### PR TITLE
Fix #47 and add new tests for it

### DIFF
--- a/Hypodermic.Tests/NestedContainerTests.cpp
+++ b/Hypodermic.Tests/NestedContainerTests.cpp
@@ -270,6 +270,84 @@ namespace Testing
         BOOST_CHECK_EQUAL(components.size(), componentsFromNestedContainer.size());
     }
 
+    BOOST_AUTO_TEST_CASE(should_resolve_instance_from_base_container)
+    {
+        // Arrange
+        ContainerBuilder builder;
+        builder.registerInstance(std::make_shared<DefaultConstructible1>());
+
+        auto container = builder.build();
+
+        ContainerBuilder nestedBuilder;
+        auto nestedContainer = nestedBuilder.buildNestedContainerFrom(*container);
+
+        // Act
+        auto instance = nestedContainer->resolve<DefaultConstructible1>();
+        auto nestedInstance = container->resolve<DefaultConstructible1>();
+
+        // Assert
+        BOOST_CHECK_EQUAL(instance, nestedInstance);
+    }
+
+    BOOST_AUTO_TEST_CASE(should_resolve_instance_with_interface_from_base_container)
+    {
+        // Arrange
+        ContainerBuilder builder;
+        builder.registerInstance(std::make_shared<DefaultConstructible1>()).as<DefaultConstructibleBase>();
+
+        auto container = builder.build();
+
+        ContainerBuilder nestedBuilder;
+        auto nestedContainer = nestedBuilder.buildNestedContainerFrom(*container);
+
+        // Act
+        auto instance = nestedContainer->resolve<DefaultConstructibleBase>();
+        auto nestedInstance = container->resolve<DefaultConstructibleBase>();
+
+        // Assert
+        BOOST_CHECK_EQUAL(instance, nestedInstance);
+    }
+
+    BOOST_AUTO_TEST_CASE(should_resolve_single_instance_from_base_container)
+    {
+        // Arrange
+        ContainerBuilder builder;
+        builder.registerType<DefaultConstructible1>().singleInstance();
+
+        auto container = builder.build();
+
+        ContainerBuilder nestedBuilder;
+        auto nestedContainer = nestedBuilder.buildNestedContainerFrom(*container);
+
+        // Act
+        auto nestedInstance = nestedContainer->resolve<DefaultConstructible1>();
+
+        auto instance = container->resolve<DefaultConstructible1>();
+
+        // Assert
+        BOOST_CHECK_EQUAL(instance, nestedInstance);
+    }
+
+    BOOST_AUTO_TEST_CASE(should_resolve_single_instance_with_interface_from_base_container)
+    {
+        // Arrange
+        ContainerBuilder builder;
+        builder.registerType<DefaultConstructible1>().as<DefaultConstructibleBase>().asSelf().singleInstance();
+
+        auto container = builder.build();
+
+        ContainerBuilder nestedBuilder;
+        auto nestedContainer = nestedBuilder.buildNestedContainerFrom(*container);
+
+        // Act
+        auto nestedInstance = nestedContainer->resolve<DefaultConstructibleBase>();
+
+        auto instance = container->resolve<DefaultConstructibleBase>();
+
+        // Assert
+        BOOST_CHECK_EQUAL(instance, nestedInstance);
+    }
+
     BOOST_AUTO_TEST_SUITE_END()
 
 } // namespace Testing

--- a/Hypodermic/PersistentInstanceRegistration.h
+++ b/Hypodermic/PersistentInstanceRegistration.h
@@ -16,7 +16,6 @@ namespace Hypodermic
         explicit PersistentInstanceRegistration(const std::shared_ptr< IRegistration >& registration)
             : m_registration(registration)
         {
-            std::static_pointer_cast<Registration>(m_registration)->m_registrationLifetime = InstanceLifetimes::Persistent;
         }
 
         const TypeInfo& instanceType() const override

--- a/Hypodermic/PersistentInstanceRegistration.h
+++ b/Hypodermic/PersistentInstanceRegistration.h
@@ -8,6 +8,7 @@
 
 namespace Hypodermic
 {
+    class Registration;
 
     class PersistentInstanceRegistration : public IRegistration
     {
@@ -15,6 +16,7 @@ namespace Hypodermic
         explicit PersistentInstanceRegistration(const std::shared_ptr< IRegistration >& registration)
             : m_registration(registration)
         {
+            std::static_pointer_cast<Registration>(m_registration)->m_registrationLifetime = InstanceLifetimes::Persistent;
         }
 
         const TypeInfo& instanceType() const override

--- a/Hypodermic/Registration.h
+++ b/Hypodermic/Registration.h
@@ -25,12 +25,14 @@ namespace Hypodermic
                      const InstanceFactory& instanceFactory,
                      const DependencyFactories& dependencyFactories,
                      const ActivationHandlers& activationHandlers,
-                     bool isFallback)
+                     bool isFallback,
+                     InstanceLifetimes::InstanceLifetime registrationLifetime)
             : m_activator(*this, instanceFactory, activationHandlers)
             , m_instanceType(instanceType)
             , m_typeAliases(typeAliases)
             , m_dependencyFactories(dependencyFactories)
             , m_isFallback(isFallback)
+            , m_registrationLifetime(registrationLifetime)
         {
         }
 
@@ -75,9 +77,7 @@ namespace Hypodermic
         DependencyFactories m_dependencyFactories;
         bool m_isFallback;
 
-
-        friend class PersistentInstanceRegistration;
-        InstanceLifetimes::InstanceLifetime m_registrationLifetime = InstanceLifetimes::Transient;
+        InstanceLifetimes::InstanceLifetime m_registrationLifetime;
     };
 
 } // namespace Hypodermic

--- a/Hypodermic/Registration.h
+++ b/Hypodermic/Registration.h
@@ -60,7 +60,7 @@ namespace Hypodermic
 
         InstanceLifetimes::InstanceLifetime instanceLifetime() const override
         {
-            return InstanceLifetimes::Transient;
+            return m_registrationLifetime;
         }
 
         bool isFallback() const override
@@ -74,6 +74,10 @@ namespace Hypodermic
         TypeAliases m_typeAliases;
         DependencyFactories m_dependencyFactories;
         bool m_isFallback;
+
+
+        friend class PersistentInstanceRegistration;
+        InstanceLifetimes::InstanceLifetime m_registrationLifetime = InstanceLifetimes::Transient;
     };
 
 } // namespace Hypodermic

--- a/Hypodermic/RegistrationActivator.h
+++ b/Hypodermic/RegistrationActivator.h
@@ -40,7 +40,17 @@ namespace Hypodermic
                 return nullptr;
             }
 
-            return m_instanceFactory(m_registration, resolutionContext);
+            if (m_registration.instanceLifetime() == InstanceLifetimes::Transient)
+            {
+                return m_instanceFactory(m_registration, resolutionContext);
+            }
+
+            if (!m_instance)
+            {
+                m_instance = m_instanceFactory(m_registration, resolutionContext);
+            }
+
+            return m_instance;
         }
 
         void raiseActivated(ComponentContext& container, const std::shared_ptr< void >& instance) override
@@ -52,6 +62,7 @@ namespace Hypodermic
         const IRegistration& m_registration;
         InstanceFactory m_instanceFactory;
         boost::signals2::signal< void(ComponentContext&, const std::shared_ptr< void >&) > m_activated;
+        std::shared_ptr<void> m_instance;
     };
 
 } // namespace Hypodermic

--- a/Hypodermic/RegistrationBuilder.h
+++ b/Hypodermic/RegistrationBuilder.h
@@ -36,7 +36,14 @@ namespace Hypodermic
                                                       const DependencyFactories& dependencyFactories,
                                                       const ActivationHandlers& activationHandlers)
         {
-            return std::make_shared< Registration >(instanceType, typeAliases, instanceFactory, dependencyFactories, activationHandlers, IsFallback::value);
+            return std::make_shared< Registration >(
+                    instanceType,
+                    typeAliases,
+                    instanceFactory,
+                    dependencyFactories,
+                    activationHandlers,
+                    IsFallback::value,
+                    InstanceLifetimes::Transient);
         }
     };
 
@@ -55,14 +62,14 @@ namespace Hypodermic
         {
             return std::make_shared< PersistentInstanceRegistration >
             (
-                RegistrationBuilder< TRegistrationDescriptorInfo, TransientInstance >::build
-                (
-                    instanceType,
-                    typeAliases,
-                    instanceFactory,
-                    dependencyFactories,
-                    activationHandlers
-                )
+                    std::make_shared< Registration >(
+                            instanceType,
+                            typeAliases,
+                            instanceFactory,
+                            dependencyFactories,
+                            activationHandlers,
+                            IsFallback::value,
+                            InstanceLifetimes::Persistent)
             );
         }
 

--- a/Hypodermic/RuntimeRegistrationBuilder.h
+++ b/Hypodermic/RuntimeRegistrationBuilder.h
@@ -23,7 +23,8 @@ namespace Hypodermic
                 instanceFactory,
                 DependencyFactories(),
                 ActivationHandlers(),
-                false /* not a fallback registration */
+                false, /* not a fallback registration */
+                InstanceLifetimes::Transient
             );
         }
     };


### PR DESCRIPTION
I found a fix in a bug that I reported in #47 
Unfortunately I'm not convinced that this a a clean solution and would like to have feedback. Especially weird part is the `PersistentInstanceRegistration` which holds `m_registration` member which actually is a `Registration` (Is this intentional?). When I tried to fetch instanceLifetime in Activator it then returned transient, which was incorrect. So I tried to fix this with ugly friend class solution which is more or less hack.

This will however fix the problem and all the tests still pass...

EDIT: passing the lifetime to registration as parameter. 