### PR TITLE
Added Conan Packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ obj/**
 *ReSharper*
 *.VC.*
 .vs/*
+compile_commands.json
+CMakeUserPresets.json
+test_package/CMakeUserPresets.json
+test_package/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMPILER_FLAGS} ${WARNING_FLAGS}")
 
 
 add_subdirectory(Hypodermic)
-add_subdirectory(Hypodermic.Tests)
+if (NOT BUILD_TESTING STREQUAL OFF)
+	add_subdirectory(Hypodermic.Tests)
+endif()
 
 
 # uninstall target

--- a/Hypodermic.Tests/CMakeLists.txt
+++ b/Hypodermic.Tests/CMakeLists.txt
@@ -34,10 +34,10 @@ set(HypodermicTests_sources
 
 include_directories("..")
 
-add_definitions(-DBOOST_TEST_DYN_LINK)
+# add_definitions(-DBOOST_TEST_DYN_LINK)
 
 add_executable(Hypodermic.Tests ${HypodermicTests_sources})
-target_link_libraries(Hypodermic.Tests ${Boost_LIBRARIES})
+target_link_libraries(Hypodermic.Tests Boost::unit_test_framework)
 
 add_test(cmake_Hypodermic.Tests ${CMAKE_CURRENT_BINARY_DIR}/Hypodermic.Tests --result_code=no --report_level=no)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,48 @@
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
+from conan.tools.files import copy
+import os
+from os.path import join
+
+
+class BasicConanfile(ConanFile):
+    name = "hypodermic"
+    version = "2.5.3"
+    description = "Hypodermic is an IoC container for C++. It provides dependency injection to your existing design."
+    license = "MIT"
+    homepage = "github.com/ybainier/Hypodermic.git"
+    settings = "build_type"
+    default_options = {"boost/*:shared": True}
+    exports_sources = "Hypodermic/*", "Hypodermic.Tests/*"
+
+    def requirements(self):
+        self.requires("boost/1.81.0")
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.variables["CMAKE_EXPORT_COMPILE_COMMANDS"] = True
+        tc.generate()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        if not self.conf.get("tools.build:skip_test", default=False):
+            cmake = CMake(self)
+            cmake.configure(build_script_folder="Hypodermic.Tests")
+            cmake.build()
+            self.run(join(self.cpp.build.bindir, "Hypodermic.Tests"))
+
+    def package(self):
+        copy(
+            self,
+            "*.h",
+            join(self.source_folder, "Hypodermic"),
+            join(self.package_folder, "include/Hypodermic"),
+            keep_path=False,
+        )
+
+    def package_id(self):
+        self.info.clear()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(PackageTest CXX)
+
+find_package(hypodermic REQUIRED)
+
+add_executable(example src/example.cpp)
+target_link_libraries(example hypodermic::hypodermic)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class helloTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "example")
+            self.run(cmd, env="conanrun")

--- a/test_package/src/example.cpp
+++ b/test_package/src/example.cpp
@@ -1,0 +1,4 @@
+#include <Hypodermic/Hypodermic.h>
+
+int main() {
+}


### PR DESCRIPTION
Hi,

here is a conanfile.py for packaging this project.
Included in this PR are also some minor changes to the build-system. These were required in order to get the tests to compile and give the option to skip the tests.
Please check if it still builds on your end.
The `test_package` folder includes a small example how to use this new package and it is used to check the validity of the package.
The package requires a very recent version of boost, as it is one of the few, with a Conan v2 recipe like this one. This may be fine-tuned later.

May I also contribute a modified version of this recipe to conan-center?

kind regards,

Max 