### PR TITLE
Fix issue resolving const dependencies

### DIFF
--- a/Hypodermic.Tests/CMakeLists.txt
+++ b/Hypodermic.Tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(HypodermicTests_sources
     ProvidedInstanceFactoryRegistrationTests.cpp
     ProvidedInstanceRegistrationTests.cpp
     RegistrationTests.cpp
+    ResolveConstPtrTests.cpp
     RuntimeRegistrationTests.cpp
     UseIfNoneTests.cpp
 )

--- a/Hypodermic.Tests/ResolveConstPtrTests.cpp
+++ b/Hypodermic.Tests/ResolveConstPtrTests.cpp
@@ -1,0 +1,91 @@
+#include "stdafx.h"
+
+#include "Hypodermic/ContainerBuilder.h"
+
+
+namespace Hypodermic
+{
+namespace Testing
+{
+namespace
+{
+
+    class Foo
+    {
+    public:
+        int value() const
+        {
+            return 42;
+        }
+    };
+
+    class Bar
+    {
+    public:
+        explicit Bar(std::shared_ptr<Foo> foo) noexcept : _foo(std::move(foo))
+        { }
+
+        const std::shared_ptr<Foo>& foo() const noexcept
+        {
+            return _foo;
+        }
+
+    private:
+        std::shared_ptr<Foo> _foo;
+    };
+
+    class Baz
+    {
+    public:
+        explicit Baz(std::shared_ptr<const Foo> foo) noexcept : _foo(std::move(foo))
+        { }
+
+        const std::shared_ptr<const Foo>& foo() const noexcept
+        {
+            return _foo;
+        }
+
+    private:
+        std::shared_ptr<const Foo> _foo;
+    };
+
+} // namespace
+
+    BOOST_AUTO_TEST_SUITE(ResolveConstPtrTests)
+
+    BOOST_AUTO_TEST_CASE(should_resolve_non_const_ptr)
+    {
+        // Arrange
+        ContainerBuilder builder;
+        builder.registerType<Foo>();
+        builder.registerType<Bar>();
+        auto container = builder.build();
+
+        // Act
+        const auto bar = container->resolve<Bar>();
+        auto value = bar->foo()->value();
+
+        // Assert
+        BOOST_CHECK_EQUAL(value, 42);
+    }
+
+    BOOST_AUTO_TEST_CASE(should_resolve_const_ptr)
+    {
+        // Arrange
+        ContainerBuilder builder;
+        builder.registerType<Foo>();
+        builder.registerType<Baz>();
+        auto container = builder.build();
+
+        // Act
+        const auto baz = container->resolve<Bar>();
+        auto value = baz->foo()->value();
+
+        // Assert
+        BOOST_CHECK_EQUAL(value, 42);
+    }
+
+    BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace Testing
+} // namespace Hypodermic

--- a/Hypodermic/ArgumentResolver.h
+++ b/Hypodermic/ArgumentResolver.h
@@ -38,6 +38,25 @@ namespace Traits
     };
 
 
+	template <class TArg>
+	struct ArgumentResolver< std::shared_ptr< const TArg > >
+	{
+		typedef std::shared_ptr< const TArg > Type;
+
+		template <class TRegistration, class TResolutionContext>
+		static Type resolve(const TRegistration& registration, TResolutionContext& resolutionContext)
+		{
+			static_assert(IsComplete< TArg >::value, "TArg should be a complete type");
+
+			auto&& factory = registration.getDependencyFactory(Utils::getMetaTypeInfo< TArg >());
+			if (factory)
+				return std::shared_ptr< const TArg >(std::static_pointer_cast<TArg>(factory(resolutionContext.componentContext())));
+
+			return std::shared_ptr< const TArg >(resolutionContext.componentContext().template resolve< TArg >());
+		}
+	};
+
+
     template <class TArg>
     struct ArgumentResolver< std::vector< std::shared_ptr< TArg > > >
     {


### PR DESCRIPTION
Ran into an issue trying to resolve a `std::shared_ptr<const ...>`  as an autowired dependency. I don't know whether this was intentional or not, but I believe resolving const dependencies is a legitimate usecase

The issue was that the existing `ArgumentResolver` specialization would try specialize where `TArg` included the `const` and this could not cast to `std::shared_ptr<void>` without loss of const qualification

To fix I have added an overload of `ArgumentResolver` that specializes for const types; it resolves the non-const type and converts to const after that. There are two test cases that fail without the new specialization and pass with it

Let me know if there are any changes you would need to accept this PR

Thanks