### PR TITLE
Resolve const

### DIFF
--- a/Hypodermic.Tests/CMakeLists.txt
+++ b/Hypodermic.Tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(HypodermicTests_sources
     ProvidedInstanceFactoryRegistrationTests.cpp
     ProvidedInstanceRegistrationTests.cpp
     RegistrationTests.cpp
+    ResolveConstPtrTests.cpp
     RuntimeRegistrationTests.cpp
     UseIfNoneTests.cpp
 )

--- a/Hypodermic.Tests/ResolveConstPtrTests.cpp
+++ b/Hypodermic.Tests/ResolveConstPtrTests.cpp
@@ -1,0 +1,91 @@
+#include "stdafx.h"
+
+#include "Hypodermic/ContainerBuilder.h"
+
+
+namespace Hypodermic
+{
+namespace Testing
+{
+namespace
+{
+
+    class Foo
+    {
+    public:
+        int value() const
+        {
+            return 42;
+        }
+    };
+
+    class Bar
+    {
+    public:
+        explicit Bar(std::shared_ptr<Foo> foo) noexcept : _foo(std::move(foo))
+        { }
+
+        const std::shared_ptr<Foo>& foo() const noexcept
+        {
+            return _foo;
+        }
+
+    private:
+        std::shared_ptr<Foo> _foo;
+    };
+
+    class Baz
+    {
+    public:
+        explicit Baz(std::shared_ptr<const Foo> foo) noexcept : _foo(std::move(foo))
+        { }
+
+        const std::shared_ptr<const Foo>& foo() const noexcept
+        {
+            return _foo;
+        }
+
+    private:
+        std::shared_ptr<const Foo> _foo;
+    };
+
+} // namespace
+
+    BOOST_AUTO_TEST_SUITE(ResolveConstPtrTests)
+
+    BOOST_AUTO_TEST_CASE(should_resolve_non_const_ptr)
+    {
+        // Arrange
+        ContainerBuilder builder;
+        builder.registerType<Foo>();
+        builder.registerType<Bar>();
+        auto container = builder.build();
+
+        // Act
+        const auto bar = container->resolve<Bar>();
+        auto value = bar->foo()->value();
+
+        // Assert
+        BOOST_CHECK_EQUAL(value, 42);
+    }
+
+    BOOST_AUTO_TEST_CASE(should_resolve_const_ptr)
+    {
+        // Arrange
+        ContainerBuilder builder;
+        builder.registerType<Foo>();
+        builder.registerType<Baz>();
+        auto container = builder.build();
+
+        // Act
+        const auto baz = container->resolve<Baz>();
+        auto value = baz->foo()->value();
+
+        // Assert
+        BOOST_CHECK_EQUAL(value, 42);
+    }
+
+    BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace Testing
+} // namespace Hypodermic

--- a/Hypodermic.Tests/ResolveConstPtrTests.cpp
+++ b/Hypodermic.Tests/ResolveConstPtrTests.cpp
@@ -58,6 +58,36 @@ namespace
         // Arrange
         ContainerBuilder builder;
         builder.registerType<Foo>();
+        auto container = builder.build();
+
+        // Act
+        const auto foo = container->resolve<Foo>();
+        auto value = foo->value();
+
+        // Assert
+        BOOST_CHECK_EQUAL(value, 42);
+    }
+
+    BOOST_AUTO_TEST_CASE(should_resolve_const_ptr)
+    {
+        // Arrange
+        ContainerBuilder builder;
+        builder.registerType<Foo>();
+        auto container = builder.build();
+
+        // Act
+        const auto cfoo = container->resolve<const Foo>();
+        auto value = cfoo->value();
+
+        // Assert
+        BOOST_CHECK_EQUAL(value, 42);
+    }
+
+    BOOST_AUTO_TEST_CASE(should_resolve_non_const_ptr_argument)
+    {
+        // Arrange
+        ContainerBuilder builder;
+        builder.registerType<Foo>();
         builder.registerType<Bar>();
         auto container = builder.build();
 
@@ -69,7 +99,7 @@ namespace
         BOOST_CHECK_EQUAL(value, 42);
     }
 
-    BOOST_AUTO_TEST_CASE(should_resolve_const_ptr)
+    BOOST_AUTO_TEST_CASE(should_resolve_const_ptr_argument)
     {
         // Arrange
         ContainerBuilder builder;

--- a/Hypodermic/ComponentContext.h
+++ b/Hypodermic/ComponentContext.h
@@ -156,11 +156,12 @@ namespace Hypodermic
         template <class T>
         bool tryToRegisterType(IRegistrationScope& scope, std::true_type /* T has autowireable constructor */)
         {
-            auto&& factory = Traits::ConstructorDescriptor< T >::describe();
+            using MutableT = std::remove_const_t<T>;
+            auto&& factory = Traits::ConstructorDescriptor< MutableT >::describe();
 
             scope.addRegistration(m_runtimeRegistrationBuilder->build
             (
-                Utils::getMetaTypeInfo< T >(),
+                Utils::getMetaTypeInfo< MutableT >(),
                 [factory](const IRegistration& r, IResolutionContext& c) { return std::static_pointer_cast< void >(factory(r, c)); }
             ));
 


### PR DESCRIPTION
Hi. As well as JonathanHiggs in #54, I have a need to resolve const T types.

I tried his code and it allowed me to resolve an constructor argument of `std::shared_ptr<const T>`, but I couldn't compile simply `container->resolve<const T>()`.

The necessary behavior is that a `std::shared_ptr<T>` is internally created when const T is required to resolve, since `std::shared_ptr<T>` is convertible to `std::shared_ptr<const T>`.
I've fixed some lines in `ComponentContext::tryToRegisterType()` to register `std::remove_const_t<T>` instead of T itself.

I hope I didn't make a mistake nor misunderstanding.

Thanks.
