### PR TITLE
Introduce asGroup()

### DIFF
--- a/Hypodermic.Tests/CMakeLists.txt
+++ b/Hypodermic.Tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(HypodermicTests_sources
     ContainerTests.cpp
     DefaultConstructibleTests.cpp
     FactoryTests.cpp
+    GroupRegistrationTests.cpp
     IsCompleteTests.cpp
     MemoryTests.cpp
     NamedTests.cpp

--- a/Hypodermic.Tests/GroupRegistrationTests.cpp
+++ b/Hypodermic.Tests/GroupRegistrationTests.cpp
@@ -1,0 +1,208 @@
+#include "stdafx.h"
+
+#include "Hypodermic/ContainerBuilder.h"
+
+#include "TestingTypes.h"
+
+
+namespace Hypodermic
+{
+namespace Testing
+{
+
+    template <class TItem>
+    struct FilterBaseResolver
+    {
+        using Type = IFilter<TItem>;
+    };
+
+    struct GroupRegistrationFixture
+    {
+        ~GroupRegistrationFixture()
+        {
+            Behavior::configureRuntimeRegistration(true);
+        }
+    };
+
+    BOOST_FIXTURE_TEST_SUITE(GroupRegistrationTests, GroupRegistrationFixture)
+
+    BOOST_AUTO_TEST_CASE(should_register_all_types_in_a_group)
+    {
+        // Arrange
+        ContainerBuilder builder;
+
+        // Act
+        builder.registerType< TypeWithGroups >()
+            .asGroup< IGroup >()
+            .singleInstance();
+
+        auto container = builder.build();
+
+        // Assert
+        auto instance1 = container->resolve< BaseType1 >();
+        BOOST_CHECK(instance1 != nullptr);
+
+        auto derived1 = std::dynamic_pointer_cast< TypeWithGroups >(instance1);
+        BOOST_CHECK(derived1 != nullptr);
+
+        auto instance2 = container->resolve< BaseType2 >();
+        BOOST_CHECK(instance2 != nullptr);
+
+        auto derived2 = std::dynamic_pointer_cast< TypeWithGroups >(instance1);
+        BOOST_CHECK(derived2 != nullptr);
+
+        BOOST_CHECK(derived1 == derived2);
+
+        Behavior::configureRuntimeRegistration(false);
+        BOOST_CHECK_THROW(container->resolve< TypeWithGroups >(), ResolutionException);
+        BOOST_CHECK_THROW(container->resolve< IFilter<int> >(), ResolutionException);
+        BOOST_CHECK_THROW(container->resolve< IFilter<char> >(), ResolutionException);
+    }
+
+    BOOST_AUTO_TEST_CASE(should_register_all_types_in_a_group_and_self)
+    {
+        // Arrange
+        ContainerBuilder builder;
+
+        // Act
+        builder.registerType< TypeWithGroups >()
+            .asGroup< IGroup >()
+            .asSelf();
+
+        auto container = builder.build();
+
+        // Assert
+        auto instance1 = container->resolve< BaseType1 >();
+        BOOST_CHECK(instance1 != nullptr);
+
+        auto derived1 = std::dynamic_pointer_cast< TypeWithGroups >(instance1);
+        BOOST_CHECK(derived1 != nullptr);
+
+        auto instance2 = container->resolve< BaseType2 >();
+        BOOST_CHECK(instance2 != nullptr);
+
+        auto derived2 = std::dynamic_pointer_cast< TypeWithGroups >(instance1);
+        BOOST_CHECK(derived2 != nullptr);
+
+        auto self = container->resolve< TypeWithGroups >();
+        BOOST_CHECK(derived1 == derived2);
+        BOOST_CHECK(derived1 != self);
+
+        Behavior::configureRuntimeRegistration(false);
+        BOOST_CHECK_THROW(container->resolve< IFilter<int> >(), ResolutionException);
+        BOOST_CHECK_THROW(container->resolve< IFilter<char> >(), ResolutionException);
+    }
+
+    BOOST_AUTO_TEST_CASE(should_register_all_types_in_two_groups)
+    {
+        // Arrange
+        ContainerBuilder builder;
+
+        // Act
+        builder.registerType< TypeWithGroups >()
+            .asGroup< IGroup >()
+            .asGroup< IGroupWithFilter, FilterBaseResolver >();
+
+        auto container = builder.build();
+
+        // Assert
+        auto instance1 = container->resolve< BaseType1 >();
+        BOOST_CHECK(instance1 != nullptr);
+
+        auto derived1 = std::dynamic_pointer_cast< TypeWithGroups >(instance1);
+        BOOST_CHECK(derived1 != nullptr);
+
+        auto instance2 = container->resolve< BaseType2 >();
+        BOOST_CHECK(instance2 != nullptr);
+
+        auto derived2 = std::dynamic_pointer_cast< TypeWithGroups >(instance1);
+        BOOST_CHECK(derived2 != nullptr);
+
+        auto instance3 = container->resolve< IFilter<int> >();
+        BOOST_CHECK(instance3 != nullptr);
+
+        auto derived3 = std::dynamic_pointer_cast< TypeWithGroups >(instance1);
+        BOOST_CHECK(derived3 != nullptr);
+
+        auto instance4 = container->resolve< IFilter<char> >();
+        BOOST_CHECK(instance4 != nullptr);
+
+        auto derived4 = std::dynamic_pointer_cast< TypeWithGroups >(instance1);
+        BOOST_CHECK(derived4 != nullptr);
+
+        BOOST_CHECK(derived1 == derived2);
+        BOOST_CHECK(derived1 == derived3);
+        BOOST_CHECK(derived1 == derived4);
+
+        Behavior::configureRuntimeRegistration(false);
+        BOOST_CHECK_THROW(container->resolve< TypeWithGroups >(), ResolutionException);
+    }
+
+    BOOST_AUTO_TEST_CASE(should_ignore_empty_group)
+    {
+        // Arrange
+        ContainerBuilder builder;
+
+        // Act
+        builder.registerType< TypeWithEmptyGroup >()
+            .asGroup< IGroup >();
+
+        auto container = builder.build();
+
+        // Assert
+        auto instance = container->resolve< TypeWithEmptyGroup >();
+        BOOST_CHECK(instance != nullptr);
+    }
+
+    BOOST_AUTO_TEST_CASE(should_be_functional_for_registerInstance)
+    {
+        // Arrange
+        ContainerBuilder builder;
+        auto instance = std::make_shared< TypeWithGroups >();
+
+        // Act
+        builder.registerInstance(instance).asGroup< IGroup >();
+
+        auto container = builder.build();
+
+        // Assert
+        auto instance1 = container->resolve< BaseType1 >();
+        BOOST_CHECK(instance1 == instance);
+
+        auto instance2 = container->resolve< BaseType2 >();
+        BOOST_CHECK(instance2 == instance);
+
+        Behavior::configureRuntimeRegistration(false);
+        BOOST_CHECK_THROW(container->resolve< TypeWithGroups >(), ResolutionException);
+    }
+
+    BOOST_AUTO_TEST_CASE(should_be_functional_for_registerInstanceFactory)
+    {
+        // Arrange
+        ContainerBuilder builder;
+        std::shared_ptr< TypeWithGroups > instance;
+
+        // Act
+        builder.registerInstanceFactory([&instance](ComponentContext&)
+        {
+            instance = std::make_shared< TypeWithGroups >();
+            return instance;
+        }).asGroup< IGroup >();
+
+        auto container = builder.build();
+
+        // Assert
+        auto instance1 = container->resolve< BaseType1 >();
+        BOOST_CHECK(instance1 == instance);
+
+        auto instance2 = container->resolve< BaseType2 >();
+        BOOST_CHECK(instance2 == instance);
+
+        Behavior::configureRuntimeRegistration(false);
+        BOOST_CHECK_THROW(container->resolve< TypeWithGroups >(), ResolutionException);
+    }
+
+    BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace Testing
+} // namespace Hypodermic

--- a/Hypodermic.Tests/Hypodermic.Tests.vcxproj
+++ b/Hypodermic.Tests/Hypodermic.Tests.vcxproj
@@ -189,6 +189,7 @@
     <ClCompile Include="ContainerTests.cpp" />
     <ClCompile Include="DefaultConstructibleTests.cpp" />
     <ClCompile Include="FactoryTests.cpp" />
+    <ClCompile Include="GroupRegistrationTests.cpp" />
     <ClCompile Include="IsCompleteTests.cpp" />
     <ClCompile Include="main.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>

--- a/Hypodermic.Tests/Hypodermic.Tests.vcxproj.filters
+++ b/Hypodermic.Tests/Hypodermic.Tests.vcxproj.filters
@@ -59,6 +59,9 @@
     <ClCompile Include="RuntimeRegistrationTests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="GroupRegistrationTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Tests">

--- a/Hypodermic.Tests/TestingTypes.h
+++ b/Hypodermic.Tests/TestingTypes.h
@@ -228,5 +228,31 @@ namespace Testing
         std::function< std::shared_ptr< ILoader >() > factory;
     };
 
+    template <class... TBases>
+    class IGroup : public TBases...
+    {
+    };
+
+    template <class TItem>
+    class IFilter
+    {
+    public:
+        virtual ~IFilter() = default;
+    };
+
+    template <class... TItems>
+    class IGroupWithFilter : public IFilter<TItems>...
+    {
+    };
+
+    class TypeWithGroups : public IGroup<BaseType1, BaseType2>,
+                           public IGroupWithFilter<int, char>
+    {
+    };
+
+    class TypeWithEmptyGroup : public IGroup<>
+    {
+    };
+
 } // namespace Testing
 } // namespace Hypodermic

--- a/Hypodermic/AsGroup.h
+++ b/Hypodermic/AsGroup.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "Hypodermic/DefaultBaseResolver.h"
+#include "Hypodermic/EnforceBaseOf.h"
+#include "Hypodermic/TypeAliasKey.h"
+
+
+namespace Hypodermic
+{
+namespace RegistrationDescriptorOperations
+{
+
+    template
+    <
+        class TDescriptor,
+        class TDescriptorInfo
+    >
+    class AsGroup
+    {
+    private:
+        typedef typename TDescriptorInfo::InstanceType InstanceType;
+
+    public:
+        template <template <class...> class TGroup, template <class> class TBaseResolver = DefaultBaseResolver, class TDelayedDescriptor = TDescriptor>
+        typename TDelayedDescriptor::template UpdateDescriptor
+        <
+            typename TDescriptorInfo::template RegisterGroup< TGroup, TBaseResolver >::Type
+        >
+        ::Type& asGroup()
+        {
+            return asGroupItems< TGroup, TBaseResolver, TDelayedDescriptor >(static_cast<InstanceType*>(nullptr));
+        }
+
+    private:
+        template <template <class...> class TGroup, template <class> class TBaseResolver, class TDelayedDescriptor, class... TItems>
+        typename TDelayedDescriptor::template UpdateDescriptor
+        <
+            typename TDescriptorInfo::template RegisterGroup< TGroup, TBaseResolver >::Type
+        >
+        ::Type& asGroupItems(TGroup<TItems...>*)
+        {
+            auto descriptor = static_cast< TDescriptor* >(this);
+            addGroupItem< TBaseResolver, TItems... >(descriptor);
+
+            auto updatedDescriptor = descriptor->template createUpdate< typename TDescriptorInfo::template RegisterGroup< TGroup, TBaseResolver >::Type >();
+            descriptor->registrationDescriptorUpdated()(updatedDescriptor);
+
+            return *updatedDescriptor;
+        }
+
+        template <template <class> class TBaseResolver>
+        void addGroupItem(TDescriptor*)
+        {
+        }
+
+        template <template <class> class TBaseResolver, class TFirst, class... TOthers>
+        void addGroupItem(TDescriptor* descriptor)
+        {
+            typedef typename TBaseResolver<TFirst>::Type TBase;
+
+            Extensions::EnforceBaseOf< TDescriptorInfo, TBase, InstanceType >::act();
+
+            descriptor->addTypeIfMissing(createKeyForType< TBase >(), [](const std::shared_ptr< void >& x)
+            {
+                auto instanceDynamicType = std::static_pointer_cast< InstanceType >(x);
+                auto instanceStaticType = std::static_pointer_cast< TBase >(instanceDynamicType);
+                return instanceStaticType;
+            });
+
+            addGroupItem< TBaseResolver, TOthers... >(descriptor);
+        }
+
+    protected:
+        virtual ~AsGroup() = default;
+    };
+
+} // namespace RegistrationDescriptorOperations
+} // namespace Hypodermic

--- a/Hypodermic/AutowireableConstructorRegistrationDescriptor.h
+++ b/Hypodermic/AutowireableConstructorRegistrationDescriptor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Hypodermic/As.h"
+#include "Hypodermic/AsGroup.h"
 #include "Hypodermic/AsSelf.h"
 #include "Hypodermic/ConstructorDescriptor.h"
 #include "Hypodermic/InstanceFactory.h"
@@ -20,6 +21,7 @@ namespace Hypodermic
     template <class TDescriptorInfo>
     class AutowireableConstructorRegistrationDescriptor : public RegistrationDescriptorBase< AutowireableConstructorRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
                                                           public RegistrationDescriptorOperations::As< AutowireableConstructorRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
+                                                          public RegistrationDescriptorOperations::AsGroup< AutowireableConstructorRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
                                                           public RegistrationDescriptorOperations::AsSelf< AutowireableConstructorRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
                                                           public RegistrationDescriptorOperations::Named< AutowireableConstructorRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
                                                           public RegistrationDescriptorOperations::OnActivated< AutowireableConstructorRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
@@ -28,6 +30,7 @@ namespace Hypodermic
                                                           public RegistrationDescriptorOperations::With< AutowireableConstructorRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >
     {
         friend class RegistrationDescriptorOperations::As< AutowireableConstructorRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;
+        friend class RegistrationDescriptorOperations::AsGroup< AutowireableConstructorRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;
         friend class RegistrationDescriptorOperations::AsSelf< AutowireableConstructorRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;
         friend class RegistrationDescriptorOperations::Named< AutowireableConstructorRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;
         friend class RegistrationDescriptorOperations::OnActivated< AutowireableConstructorRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;

--- a/Hypodermic/CMakeLists.txt
+++ b/Hypodermic/CMakeLists.txt
@@ -14,6 +14,7 @@ set(Hypodermic_headers
     ArgumentPack.h
     ArgumentResolver.h
     As.h
+    AsGroup.h
     AsSelf.h
     AutowireableConstructor.h
     AutowireableConstructorRegistrationDescriptor.h
@@ -28,6 +29,7 @@ set(Hypodermic_headers
     ContainerBuilder.h
     ContainerInstanceRegistration.h
     ContainerInstanceRegistrationActivator.h
+    DefaultBaseResolver.h
     DependencyActivationException.h
     DependencyFactories.h
     DependencyFactory.h
@@ -63,6 +65,7 @@ set(Hypodermic_headers
     MetaIdentity.h
     MetaInsert.h
     MetaMap.h
+    MetaPack.h
     MetaPair.h
     Named.h
     NamedTypeAlias.h

--- a/Hypodermic/DefaultBaseResolver.h
+++ b/Hypodermic/DefaultBaseResolver.h
@@ -1,0 +1,13 @@
+#pragma once
+
+
+namespace Hypodermic
+{
+
+    template <class TItem>
+    struct DefaultBaseResolver
+    {
+        typedef TItem Type;
+    };
+
+} // namespace Hypodermic

--- a/Hypodermic/Hypodermic.vcxproj
+++ b/Hypodermic/Hypodermic.vcxproj
@@ -173,6 +173,7 @@
     <ClInclude Include="MetaIdentity.h" />
     <ClInclude Include="MetaInsert.h" />
     <ClInclude Include="MetaMap.h" />
+    <ClInclude Include="MetaPack.h" />
     <ClInclude Include="MetaPair.h" />
     <ClInclude Include="Named.h" />
     <ClInclude Include="NamedTypeAlias.h" />
@@ -185,6 +186,7 @@
     <ClInclude Include="ArgumentResolver.h" />
     <ClInclude Include="ArgumentPack.h" />
     <ClInclude Include="As.h" />
+    <ClInclude Include="AsGroup.h" />
     <ClInclude Include="AsSelf.h" />
     <ClInclude Include="AutowireableConstructor.h" />
     <ClInclude Include="AutowireableConstructorRegistrationDescriptor.h" />
@@ -198,6 +200,7 @@
     <ClInclude Include="ContainerBuilder.h" />
     <ClInclude Include="ContainerInstanceRegistration.h" />
     <ClInclude Include="ContainerInstanceRegistrationActivator.h" />
+    <ClInclude Include="DefaultBaseResolver.h" />
     <ClInclude Include="DependencyActivationException.h" />
     <ClInclude Include="DependencyFactories.h" />
     <ClInclude Include="DependencyFactory.h" />

--- a/Hypodermic/Hypodermic.vcxproj.filters
+++ b/Hypodermic/Hypodermic.vcxproj.filters
@@ -71,6 +71,9 @@
     <ClInclude Include="As.h">
       <Filter>Descriptors\Operations</Filter>
     </ClInclude>
+    <ClInclude Include="AsGroup.h">
+      <Filter>Descriptors\Operations</Filter>
+    </ClInclude>
     <ClInclude Include="AsSelf.h">
       <Filter>Descriptors\Operations</Filter>
     </ClInclude>
@@ -198,6 +201,9 @@
     <ClInclude Include="IsSupportedArgument.h">
       <Filter>Traits</Filter>
     </ClInclude>
+    <ClInclude Include="DefaultBaseResolver.h">
+      <Filter>Traits</Filter>
+    </ClInclude>
     <ClInclude Include="RuntimeRegistrationBuilder.h">
       <Filter>Registrations</Filter>
     </ClInclude>
@@ -278,6 +284,9 @@
       <Filter>Meta</Filter>
     </ClInclude>
     <ClInclude Include="MetaIdentity.h">
+      <Filter>Meta</Filter>
+    </ClInclude>
+    <ClInclude Include="MetaPack.h">
       <Filter>Meta</Filter>
     </ClInclude>
     <ClInclude Include="MetaPair.h">

--- a/Hypodermic/MetaPack.h
+++ b/Hypodermic/MetaPack.h
@@ -1,0 +1,13 @@
+#pragma once
+
+
+namespace Hypodermic
+{
+
+    template <class... T>
+    struct MetaPack
+    {
+        static const int count = static_cast< int >(sizeof...(T));
+    };
+
+} // namespace Hypodermic

--- a/Hypodermic/ProvidedInstanceFactoryRegistrationDescriptor.h
+++ b/Hypodermic/ProvidedInstanceFactoryRegistrationDescriptor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Hypodermic/As.h"
+#include "Hypodermic/AsGroup.h"
 #include "Hypodermic/AsSelf.h"
 #include "Hypodermic/InstanceFactory.h"
 #include "Hypodermic/Log.h"
@@ -18,6 +19,7 @@ namespace Hypodermic
     template <class TDescriptorInfo>
     class ProvidedInstanceFactoryRegistrationDescriptor : public RegistrationDescriptorBase< ProvidedInstanceFactoryRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
                                                           public RegistrationDescriptorOperations::As< ProvidedInstanceFactoryRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
+                                                          public RegistrationDescriptorOperations::AsGroup< ProvidedInstanceFactoryRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
                                                           public RegistrationDescriptorOperations::AsSelf< ProvidedInstanceFactoryRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
                                                           public RegistrationDescriptorOperations::Named< ProvidedInstanceFactoryRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
                                                           public RegistrationDescriptorOperations::OnActivated< ProvidedInstanceFactoryRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
@@ -25,6 +27,7 @@ namespace Hypodermic
                                                           public RegistrationDescriptorOperations::UseIfNone< ProvidedInstanceFactoryRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >
     {
         friend class RegistrationDescriptorOperations::As< ProvidedInstanceFactoryRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;
+        friend class RegistrationDescriptorOperations::AsGroup< ProvidedInstanceFactoryRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;
         friend class RegistrationDescriptorOperations::AsSelf< ProvidedInstanceFactoryRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;
         friend class RegistrationDescriptorOperations::Named< ProvidedInstanceFactoryRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;
         friend class RegistrationDescriptorOperations::OnActivated< ProvidedInstanceFactoryRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;

--- a/Hypodermic/ProvidedInstanceRegistrationDescriptor.h
+++ b/Hypodermic/ProvidedInstanceRegistrationDescriptor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Hypodermic/As.h"
+#include "Hypodermic/AsGroup.h"
 #include "Hypodermic/AsSelf.h"
 #include "Hypodermic/Log.h"
 #include "Hypodermic/Named.h"
@@ -15,11 +16,13 @@ namespace Hypodermic
     template <class TDescriptorInfo>
     class ProvidedInstanceRegistrationDescriptor : public RegistrationDescriptorBase< ProvidedInstanceRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
                                                    public RegistrationDescriptorOperations::As< ProvidedInstanceRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
+                                                   public RegistrationDescriptorOperations::AsGroup< ProvidedInstanceRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
                                                    public RegistrationDescriptorOperations::AsSelf< ProvidedInstanceRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
                                                    public RegistrationDescriptorOperations::Named< ProvidedInstanceRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >,
                                                    public RegistrationDescriptorOperations::UseIfNone< ProvidedInstanceRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >
     {
         friend class RegistrationDescriptorOperations::As< ProvidedInstanceRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;
+        friend class RegistrationDescriptorOperations::AsGroup< ProvidedInstanceRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;
         friend class RegistrationDescriptorOperations::AsSelf< ProvidedInstanceRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;
         friend class RegistrationDescriptorOperations::Named< ProvidedInstanceRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;
         friend class RegistrationDescriptorOperations::UseIfNone< ProvidedInstanceRegistrationDescriptor< TDescriptorInfo >, TDescriptorInfo >;

--- a/Hypodermic/RegistrationDescriptorInfo.h
+++ b/Hypodermic/RegistrationDescriptorInfo.h
@@ -103,20 +103,20 @@ namespace Hypodermic
         private:
             template <class... TItems>
             static auto deduceItems(TGroup< TItems... >*)
-                -> MetaPack< typename TBaseResolver<TItems>::Type... >
+                -> MetaPack< typename TBaseResolver< TItems >::Type... >
             {
             }
 
-            typedef decltype(deduceItems(static_cast< InstanceType* >(nullptr))) TPack;
-
         public:
+            typedef decltype(deduceItems(static_cast< InstanceType* >(nullptr))) PackType;
+
             typedef RegistrationDescriptorInfo
             <
                 InstanceType,
                 InstanceLifetime::value,
                 SelfRegistrationTag,
                 FallbackRegistrationTag,
-                typename std::conditional< (TPack::count > 0), typename MetaInsert< RegisteredBases, MetaPair< TPack, MetaIdentity< TPack > > >::Type, RegisteredBases >::type,
+                typename std::conditional< (PackType::count > 0), typename MetaInsert< RegisteredBases, MetaPair< PackType, MetaIdentity< PackType > > >::Type, RegisteredBases >::type,
                 Dependencies
             >
             Type;


### PR DESCRIPTION
This PR introduces `asGroup()` to register multiple abstraction(s) at once.

For example, consider the following case:
```cpp
template <class... TBases>
class ISomeGroup : public TBases... {};

class FooBar : public ISomeGroup<IBaseA, IBaseB>, public IBaseC {};
/*
  FooBar hierarchy:
    IBaseA ----+- ISomeGroup<IBaseA, IBaseB>----+- FooBar
    IBaseB ---/                                /
    IBaseC -----------------------------------/
*/
```

In this case, `IBaseA` and `IBaseB` can be registered together as follows:
```cpp
Hypodermic::ContainerBuilder builder;
builder.registerType<FooBar>()
    .asGroup<ISomeGroup>();  // This works like: .as<IBaseA>().as<IBaseB>()
```
(`IBaseC` that are not included in an `ISomeGroup<...>` are not registered by `asGroup()`, but can be registered individually by `as<IBaseC>()`.)

Additionally, we can change how the base class is resolved:
```cpp
template <class... TItems>
class ISomeGroup2 : public ISomeBase<TItems>... {};

class FooBar2 : public ISomeGroup2<int, char> {};
/*
  FooBar2 hierarchy:
    ISomeBase<int> ----+- ISomeGroup2<int, char> --- FooBar2
    ISomeBase<char> --/
*/
```

In this case, `ISomeBase<int>` and `ISomeBase<char>` can be registered together with a custom resolver as follows:
```cpp
template <class T>
struct SomeResolver
{
    using Type = ISomeBase<T>;
};

Hypodermic::ContainerBuilder builder;
builder.registerType<FooBar2>()
    .asGroup<ISomeGroup2, SomeResolver>();
    // ^This works like: .as<ISomeBase<int>>().as<ISomeBase<char>>()
```

Thanks,